### PR TITLE
Allow package to be transformed using reactify

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
       "node_modules/react",
       "node_modules/jquery"
     ]
+  },
+  "browserify": {
+    "transform": ["reactify"]
   }
 }


### PR DESCRIPTION
I was having trouble using this package with browserify and reactify, until I found [this thread](https://github.com/andreypopp/reactify/issues/20). Basically, reactify will not transform `.jsx` files that are stored in the `node_modules` folder, which causes issues like the following:

    Parsing file .../node_modules/react-anything-sortable/Sortable.jsx: Unexpected token (378:6)

The solution is to add a line to the `package.json` that marks the package as being required to be transformed by reactify first.