### PR TITLE
Fixed unbound handleSortableItemReadyToMove when using mixin-style.

### DIFF
--- a/src/SortableItemMixin.js
+++ b/src/SortableItemMixin.js
@@ -133,8 +133,8 @@ export default (Component) => {
         style: this.props.sortableStyle,
         key: this.props.sortableIndex,
         sortHandle: this.props.sortHandle,
-        onMouseDown: this.handleSortableItemReadyToMove,
-        onTouchStart: this.handleSortableItemReadyToMove
+        onMouseDown: ::this.handleSortableItemReadyToMove,
+        onTouchStart: ::this.handleSortableItemReadyToMove
       });
     }
   };


### PR DESCRIPTION
I've been trying to get sorting working using the Mixin way. Turns out the `handleSortableItemReadyToMove` func is not bound which leads to a type error when it tries to access `this.props.sortHandle`.

I have added the necessary binding.