### PR TITLE
Fixed dragging down issue when sorting vertically

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -284,7 +284,7 @@ const Sortable = React.createClass({
         } else if (relativeTop < item.fullHeight / 2 && direction === 'up') {
           newIndex = index;
         } else if (relativeTop > item.fullHeight / 2 && direction === 'down') {
-          newIndex = index+1;
+          newIndex = Math.min(index + 1, _dimensionArr.length - 1);
         } else {
           return true;
         }

--- a/src/index.js
+++ b/src/index.js
@@ -284,7 +284,7 @@ const Sortable = React.createClass({
         } else if (relativeTop < item.fullHeight / 2 && direction === 'up') {
           newIndex = index;
         } else if (relativeTop > item.fullHeight / 2 && direction === 'down') {
-          newIndex = index;
+          newIndex = index+1;
         } else {
           return true;
         }


### PR DESCRIPTION
Horizontal sorting worked fine. But if you wanted to sort vertically, you needed to drag below the desired position to select that position. I therefore added to the index instead of selecting the current when dragging down.