### PR TITLE
Less hackish solution for dynamic items

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ Constrain dragging area within sortable container.
 
 [demo](http://jasonslyvia.github.io/react-anything-sortable/demo/index.html#/containment)
 
+### dynamic
+
+Type: Bool Default: false
+
+Dynamically update the sortable when its children change. If using this option, make sure to use the onSort callback to update the order of the children passed to the Sortable component when the user sorts!
+
+[demo](http://jasonslyvia.github.io/react-anything-sortable/demo/index.html#/dynamic)
+
 ### sortHandle
 
 Type: String Default: undefined
@@ -139,7 +147,7 @@ Will be returned by `onSort` callback in the form of array.
 
 1. Specify your style for `Sortable` and `Sortable Items`, check `sortable.css`, **it is NOT optional!**
 2. Don't forget the `this.renderWithSortable` call in `SortableItem`, or spread props to your component if using decorators.
-3. Since we can't track any children modification in `Sortable`, you have to use `key` to force update `Sortable` when adding/removing children. Checkout [dynamic demo](http://jasonslyvia.github.io/react-anything-sortable/demo/#/dynamic) for more details.
+3. In order to dynamically add or remove `SortableItem`s or change their order from outside the `Sortable`, you must use the `dynamic` option. This also requires using the `onSort` callback to update the order of the children when sorting happens.
 4. Make sure to add `draggable={false}` to images within sortable components to prevent glitching. See [here](https://github.com/jasonslyvia/react-anything-sortable/blob/master/demo/components/ImageItem.js) for an example.
 
 

--- a/demo/pages/dynamic.js
+++ b/demo/pages/dynamic.js
@@ -8,18 +8,15 @@ export default class Dynamic extends React.Component {
     this.state = {
       arr: [998, 225, 13]
     };
-    this._sortableKey = 0;
   }
 
   handleSort(sortedArray) {
-    this._sortableKey++;
     this.setState({
       arr: sortedArray
     });
   }
 
   handleAddElement() {
-    this._sortableKey++;
     this.setState({
       arr: this.state.arr.concat(Math.round(Math.random() * 1000))
     });
@@ -28,7 +25,6 @@ export default class Dynamic extends React.Component {
   handleRemoveElement(index) {
     const newArr = this.state.arr.slice();
     newArr.splice(index, 1);
-    this._sortableKey++;
 
     this.setState({
       arr: newArr
@@ -38,7 +34,7 @@ export default class Dynamic extends React.Component {
   render() {
     function renderItem(num, index) {
       return (
-        <DemoItem key={index} className="dynamic-item" sortData={num}>
+        <DemoItem key={num} className="dynamic-item" sortData={num}>
           {num}
           <span className="delete"
             onMouseDown={this.handleRemoveElement.bind(this, index)}
@@ -55,7 +51,7 @@ export default class Dynamic extends React.Component {
         </h4>
         <div className="dynamic-demo">
           <button onClick={::this.handleAddElement}>Add 1 element</button>
-          <Sortable key={this._sortableKey} onSort={::this.handleSort}>
+          <Sortable onSort={::this.handleSort} dynamic>
             {this.state.arr.map(renderItem, this)}
           </Sortable>
         </div>

--- a/demo/pages/dynamic.js
+++ b/demo/pages/dynamic.js
@@ -37,7 +37,7 @@ export default class Dynamic extends React.Component {
         <DemoItem key={num} className="dynamic-item" sortData={num}>
           {num}
           <span className="delete"
-            onMouseDown={this.handleRemoveElement.bind(this, index)}
+            onClick={this.handleRemoveElement.bind(this, index)}
           >&times;</span>
         </DemoItem>
       );

--- a/demo/pages/image.js
+++ b/demo/pages/image.js
@@ -24,11 +24,11 @@ export default class HOC extends React.Component {
         <p className="sort-result">{this.state.result}</p>
         <Sortable onSort={::this.handleSort}>
           <ImageItem src="http://ww4.sinaimg.cn/large/831e9385gw1equsc4s1hbj207y02xmx9.jpg"
-                     sortData="react" />
+                     sortData="react" key={1} />
           <ImageItem src="http://ww4.sinaimg.cn/large/831e9385gw1equsc3q8lej20fz04waa8.jpg"
-                     sortData="angular" />
+                     sortData="angular" key={2} />
           <ImageItem src="http://ww4.sinaimg.cn/large/831e9385gw1equsc46m7zj20ff02zq3h.jpg"
-                     sortData="backbone" />
+                     sortData="backbone" key={3} />
         </Sortable>
       </div>
     );

--- a/lib/index.js
+++ b/lib/index.js
@@ -518,7 +518,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        sortHandle: _this3.props.sortHandle
 	      };
 
-	      if (!_this3.props.dynamic && !item.key) {
+	      if (item.key === undefined) {
 	        sortableProps.key = index;
 	      }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -508,7 +508,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        draggingItem = _this3.renderDraggingItem(item);
 	      }
 
-	      return _react2['default'].cloneElement(item, {
+	      var sortableProps = {
 	        sortableClassName: item.props.className + ' ' + itemClassName,
 	        sortableIndex: index,
 	        onSortableItemReadyToMove: isPlaceHolder ? undefined : function (e) {
@@ -516,7 +516,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	        },
 	        onSortableItemMount: _this3.handleChildUpdate,
 	        sortHandle: _this3.props.sortHandle
-	      });
+	      };
+
+	      if (!_this3.props.dynamic && !item.key) {
+	        sortableProps.key = index;
+	      }
+
+	      return _react2['default'].cloneElement(item, sortableProps);
 	    });
 
 	    var children = Array.isArray(this.props.children) ? this.props.children : [this.props.children];

--- a/lib/index.js
+++ b/lib/index.js
@@ -501,12 +501,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	        return;
 	      }
 
-	      var isPlaceHolder = _dimensionArr[index].isPlaceHolder;
-	      var itemClassName = 'ui-sortable-item\n                             ' + (isPlaceHolder && 'ui-sortable-placeholder') + '\n                             ' + (_this3.state.isDragging && isPlaceHolder && 'visible');
-
-	      if (index === _this3._draggingIndex && isPlaceHolder) {
+	      if (index === _this3._draggingIndex) {
 	        draggingItem = _this3.renderDraggingItem(item);
 	      }
+
+	      var isPlaceHolder = _dimensionArr[index].isPlaceHolder;
+	      var itemClassName = 'ui-sortable-item\n                             ' + (isPlaceHolder && 'ui-sortable-placeholder') + '\n                             ' + (_this3.state.isDragging && isPlaceHolder && 'visible');
 
 	      var sortableProps = {
 	        sortableClassName: item.props.className + ' ' + itemClassName,

--- a/lib/index.js
+++ b/lib/index.js
@@ -106,11 +106,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	    className: _react.PropTypes.string,
 	    sortHandle: _react.PropTypes.string,
 	    containment: _react.PropTypes.bool,
+	    dynamic: _react.PropTypes.bool,
 	    children: _react.PropTypes.arrayOf(_react.PropTypes.node)
 	  },
 
-	  getInitialState: function getInitialState() {
-	    var children = Array.isArray(this.props.children) ? this.props.children : [this.props.children];
+	  setArrays: function setArrays(currentChildren) {
+	    var children = Array.isArray(currentChildren) ? currentChildren : [currentChildren];
 
 	    var sortChildren = children.filter(getSortTarget);
 	    this.sortChildren = sortChildren;
@@ -126,6 +127,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	    while (i < this._dimensionArr.length) {
 	      this._orderArr.push(i++);
 	    }
+	  },
+
+	  getInitialState: function getInitialState() {
+	    this.setArrays(this.props.children);
 
 	    return {
 	      isDragging: false,
@@ -143,6 +148,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	    this._left = rect.left + document.body.scrollLeft;
 	    this._bottom = this._top + rect.height;
 	    this._right = this._left + rect.width;
+	  },
+
+	  componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
+	    var _props = this.props;
+	    var children = _props.children;
+	    var dynamic = _props.dynamic;
+
+	    if (dynamic && nextProps.children !== children) {
+	      this.setArrays(nextProps.children);
+	    }
 	  },
 
 	  componentWillUnmount: function componentWillUnmount() {
@@ -486,15 +501,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	        return;
 	      }
 
-	      if (index === _this3._draggingIndex) {
-	        draggingItem = _this3.renderDraggingItem(item);
-	      }
-
 	      var isPlaceHolder = _dimensionArr[index].isPlaceHolder;
 	      var itemClassName = 'ui-sortable-item\n                             ' + (isPlaceHolder && 'ui-sortable-placeholder') + '\n                             ' + (_this3.state.isDragging && isPlaceHolder && 'visible');
 
+	      if (index === _this3._draggingIndex && isPlaceHolder) {
+	        draggingItem = _this3.renderDraggingItem(item);
+	      }
+
 	      return _react2['default'].cloneElement(item, {
-	        key: index,
 	        sortableClassName: item.props.className + ' ' + itemClassName,
 	        sortableIndex: index,
 	        onSortableItemReadyToMove: isPlaceHolder ? undefined : function (e) {
@@ -534,7 +548,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 	    return _react2['default'].cloneElement(item, {
 	      sortableClassName: item.props.className + ' ui-sortable-item ui-sortable-dragging',
-	      key: this._dimensionArr.length,
+	      key: '_dragging',
 	      sortableStyle: style,
 	      isDragging: true,
 	      sortHandle: this.props.sortHandle
@@ -856,7 +870,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	          sortable: true,
 	          className: sortableClassName,
 	          style: sortableStyle,
-	          key: sortableIndex,
 	          sortHandle: sortHandle,
 	          onMouseDown: this.handleSortableItemReadyToMove.bind(this),
 	          onTouchStart: this.handleSortableItemReadyToMove.bind(this)
@@ -904,7 +917,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return _react2['default'].cloneElement(item, {
 	        className: this.props.sortableClassName,
 	        style: this.props.sortableStyle,
-	        key: this.props.sortableIndex,
 	        sortHandle: this.props.sortHandle,
 	        onMouseDown: this.handleSortableItemReadyToMove,
 	        onTouchStart: this.handleSortableItemReadyToMove

--- a/src/SortableItemMixin.js
+++ b/src/SortableItemMixin.js
@@ -101,7 +101,6 @@ export default (Component) => {
             sortable={true}
             className={sortableClassName}
             style={sortableStyle}
-            key={sortableIndex}
             sortHandle={sortHandle}
             onMouseDown={::this.handleSortableItemReadyToMove}
             onTouchStart={::this.handleSortableItemReadyToMove}
@@ -133,7 +132,6 @@ export default (Component) => {
       return React.cloneElement(item, {
         className: this.props.sortableClassName,
         style: this.props.sortableStyle,
-        key: this.props.sortableIndex,
         sortHandle: this.props.sortHandle,
         onMouseDown: this.handleSortableItemReadyToMove,
         onTouchStart: this.handleSortableItemReadyToMove

--- a/src/index.js
+++ b/src/index.js
@@ -436,7 +436,7 @@ const Sortable = React.createClass({
         draggingItem = this.renderDraggingItem(item);
       }
 
-      return React.cloneElement(item, {
+      const sortableProps = {
         sortableClassName: `${item.props.className} ${itemClassName}`,
         sortableIndex: index,
         onSortableItemReadyToMove: isPlaceHolder ? undefined : (e) => {
@@ -444,7 +444,13 @@ const Sortable = React.createClass({
         },
         onSortableItemMount: this.handleChildUpdate,
         sortHandle: this.props.sortHandle
-      });
+      };
+
+      if (!this.props.dynamic && !item.key) {
+        sortableProps.key = index;
+      }
+
+      return React.cloneElement(item, sortableProps);
     });
 
     const children = Array.isArray(this.props.children) ?

--- a/src/index.js
+++ b/src/index.js
@@ -427,14 +427,14 @@ const Sortable = React.createClass({
         return;
       }
 
+      if (index === this._draggingIndex) {
+        draggingItem = this.renderDraggingItem(item);
+      }
+
       const isPlaceHolder = _dimensionArr[index].isPlaceHolder;
       const itemClassName = `ui-sortable-item
                              ${isPlaceHolder && 'ui-sortable-placeholder'}
                              ${this.state.isDragging && isPlaceHolder && 'visible'}`;
-
-      if (index === this._draggingIndex && isPlaceHolder) {
-        draggingItem = this.renderDraggingItem(item);
-      }
 
       const sortableProps = {
         sortableClassName: `${item.props.className} ${itemClassName}`,

--- a/src/index.js
+++ b/src/index.js
@@ -35,13 +35,14 @@ const Sortable = React.createClass({
     className: PropTypes.string,
     sortHandle: PropTypes.string,
     containment: PropTypes.bool,
+    dynamic: PropTypes.bool,
     children: PropTypes.arrayOf(PropTypes.node)
   },
 
-  getInitialState() {
-    const children = Array.isArray(this.props.children) ?
-                     this.props.children :
-                     [this.props.children];
+  setArrays(currentChildren) {
+    const children = Array.isArray(currentChildren) ?
+                     currentChildren :
+                     [currentChildren];
 
     const sortChildren = children.filter(getSortTarget);
     this.sortChildren = sortChildren;
@@ -55,6 +56,10 @@ const Sortable = React.createClass({
     while (i < this._dimensionArr.length) {
       this._orderArr.push(i++);
     }
+  },
+
+  getInitialState() {
+    this.setArrays(this.props.children);
 
     return {
       isDragging: false,
@@ -72,6 +77,13 @@ const Sortable = React.createClass({
     this._left = rect.left + document.body.scrollLeft;
     this._bottom = this._top + rect.height;
     this._right = this._left + rect.width;
+  },
+
+  componentWillReceiveProps(nextProps) {
+    const { children, dynamic } = this.props;
+    if (dynamic && nextProps.children !== children) {
+      this.setArrays(nextProps.children);
+    }
   },
 
   componentWillUnmount() {
@@ -415,17 +427,16 @@ const Sortable = React.createClass({
         return;
       }
 
-      if (index === this._draggingIndex) {
-        draggingItem = this.renderDraggingItem(item);
-      }
-
       const isPlaceHolder = _dimensionArr[index].isPlaceHolder;
       const itemClassName = `ui-sortable-item
                              ${isPlaceHolder && 'ui-sortable-placeholder'}
                              ${this.state.isDragging && isPlaceHolder && 'visible'}`;
 
+      if (index === this._draggingIndex && isPlaceHolder) {
+        draggingItem = this.renderDraggingItem(item);
+      }
+
       return React.cloneElement(item, {
-        key: index,
         sortableClassName: `${item.props.className} ${itemClassName}`,
         sortableIndex: index,
         onSortableItemReadyToMove: isPlaceHolder ? undefined : (e) => {
@@ -467,7 +478,7 @@ const Sortable = React.createClass({
     };
     return React.cloneElement(item, {
       sortableClassName: `${item.props.className} ui-sortable-item ui-sortable-dragging`,
-      key: this._dimensionArr.length,
+      key: '_dragging',
       sortableStyle: style,
       isDragging: true,
       sortHandle: this.props.sortHandle

--- a/src/index.js
+++ b/src/index.js
@@ -446,7 +446,7 @@ const Sortable = React.createClass({
         sortHandle: this.props.sortHandle
       };
 
-      if (!this.props.dynamic && !item.key) {
+      if (item.key === undefined) {
         sortableProps.key = index;
       }
 

--- a/test/specs/sortable-test.js
+++ b/test/specs/sortable-test.js
@@ -55,9 +55,9 @@ describe('Sortable', () => {
     beforeEach(() => {
       ReactDOM.render(
         <Sortable>
-          <DemoItem sortData="1" />
-          <DemoItem sortData="2" />
-          <DemoItem sortData="3" />
+          <DemoItem sortData="1" key={1} />
+          <DemoItem sortData="2" key={2} />
+          <DemoItem sortData="3" key={3} />
         </Sortable>
       , document.getElementById('react'));
     });
@@ -98,7 +98,7 @@ describe('Sortable', () => {
           {
             ['hello1', 'hello2', ''].map(name => {
               if (name) {
-                return (<DemoItem sortData={name} />);
+                return (<DemoItem sortData={name} key={name} />);
               }
 
               return null;
@@ -124,9 +124,9 @@ describe('Sortable', () => {
     beforeEach(() => {
       component = ReactDOM.render(
         <Sortable className="style-for-test">
-          <DemoItem sortData="1" className="item-1">1</DemoItem>
-          <DemoItem sortData="2" className="item-2">2</DemoItem>
-          <DemoItem sortData="3" className="item-3">3</DemoItem>
+          <DemoItem sortData="1" className="item-1" key={1}>1</DemoItem>
+          <DemoItem sortData="2" className="item-2" key={2}>2</DemoItem>
+          <DemoItem sortData="3" className="item-3" key={3}>3</DemoItem>
         </Sortable>
       , document.getElementById('react'));
     });
@@ -245,9 +245,9 @@ describe('Sortable', () => {
     beforeEach(() => {
       component = ReactDOM.render(
         <Sortable className="style-for-test full-width">
-          <DemoItem sortData="1" className="item-1">1</DemoItem>
-          <DemoItem sortData="2" className="item-2">2</DemoItem>
-          <DemoItem sortData="3" className="item-3">3</DemoItem>
+          <DemoItem sortData="1" className="item-1" key={1}>1</DemoItem>
+          <DemoItem sortData="2" className="item-2" key={2}>2</DemoItem>
+          <DemoItem sortData="3" className="item-3" key={3}>3</DemoItem>
         </Sortable>
       , document.getElementById('react'));
     });
@@ -285,11 +285,11 @@ describe('Sortable', () => {
       callback = chai.spy();
       component = ReactDOM.render(
         <Sortable className="style-for-test" onSort={callback}>
-          <DemoItem sortData="1" className="item-1">1</DemoItem>
-          <div style={{ float: 'left', width: '50px', height: '50px'}}>fixed</div>
-          <DemoItem sortData="2" className="item-2">2</DemoItem>
-          <div style={{ float: 'left', width: '50px', height: '50px'}}>fixed</div>
-          <DemoItem sortData="3" className="item-3">3</DemoItem>
+          <DemoItem sortData="1" className="item-1" key={1}>1</DemoItem>
+          <div style={{ float: 'left', width: '50px', height: '50px'}} key='a'>fixed</div>
+          <DemoItem sortData="2" className="item-2" key={2}>2</DemoItem>
+          <div style={{ float: 'left', width: '50px', height: '50px'}} key='b'>fixed</div>
+          <DemoItem sortData="3" className="item-3" key={3}>3</DemoItem>
         </Sortable>
       , document.getElementById('react'));
     });
@@ -326,9 +326,9 @@ describe('Sortable', () => {
 
       ReactDOM.render(
         <Sortable onSort={callback}>
-          <DemoItem sortData="1" className="item-1">1</DemoItem>
-          <DemoItem sortData="2" className="item-2">2</DemoItem>
-          <DemoItem sortData="3" className="item-3">3</DemoItem>
+          <DemoItem sortData="1" className="item-1" key={1}>1</DemoItem>
+          <DemoItem sortData="2" className="item-2" key={2}>2</DemoItem>
+          <DemoItem sortData="3" className="item-3" key={3}>3</DemoItem>
         </Sortable>
       , document.getElementById('react'));
     });
@@ -362,9 +362,9 @@ describe('Sortable', () => {
     it('should NOT move when mouse outside of Sortable container', () => {
       ReactDOM.render(
         <Sortable containment>
-          <DemoItem sortData="1" className="item-1">1</DemoItem>
-          <DemoItem sortData="2" className="item-2">2</DemoItem>
-          <DemoItem sortData="3" className="item-3">3</DemoItem>
+          <DemoItem sortData="1" className="item-1" key={1}>1</DemoItem>
+          <DemoItem sortData="2" className="item-2" key={2}>2</DemoItem>
+          <DemoItem sortData="3" className="item-3" key={3}>3</DemoItem>
         </Sortable>
       , document.getElementById('react'));
 
@@ -492,15 +492,15 @@ describe('Sortable', () => {
     it('should not move when `sortHandle` is set and target doesn\'t match', () => {
       ReactDOM.render(
         <Sortable sortHandle="handle">
-          <DemoItem sortData="1" className="item-1">
+          <DemoItem sortData="1" className="item-1" key={1}>
             1
             <span className="handle">↔</span>
           </DemoItem>
-          <DemoItem sortData="2" className="item-2">
+          <DemoItem sortData="2" className="item-2" key={2}>
             2
             <span className="handle">↔</span>
           </DemoItem>
-          <DemoItem sortData="3" className="item-3">
+          <DemoItem sortData="3" className="item-3" key={3}>
             3
             <span className="handle">↔</span>
           </DemoItem>
@@ -523,19 +523,19 @@ describe('Sortable', () => {
     it('should not throw when sort handle is/contains SVG', () => {
       ReactDOM.render(
         <Sortable sortHandle="handle">
-          <DemoItem sortData="1" className="item-1">
+          <DemoItem sortData="1" className="item-1" key={1}>
             1
             <span className="handle">
               <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.414"><path d="M.004.393H4.74l6.56 10.61-.003-10.61H16v15.214h-4.696L4.71 4.997v10.61H0L.004.393" fill-rule="nonzero"></path></svg>
             </span>
           </DemoItem>
-          <DemoItem sortData="2" className="item-2">
+          <DemoItem sortData="2" className="item-2" key={2}>
             2
             <span className="handle">
               <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.414"><path d="M.004.393H4.74l6.56 10.61-.003-10.61H16v15.214h-4.696L4.71 4.997v10.61H0L.004.393" fill-rule="nonzero"></path></svg>
             </span>
           </DemoItem>
-          <DemoItem sortData="3" className="item-3">
+          <DemoItem sortData="3" className="item-3" key={3}>
             3
             <span className="handle">
               <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.414"><path d="M.004.393H4.74l6.56 10.61-.003-10.61H16v15.214h-4.696L4.71 4.997v10.61H0L.004.393" fill-rule="nonzero"></path></svg>
@@ -555,6 +555,74 @@ describe('Sortable', () => {
       draggingItem = document.querySelector('.ui-sortable-dragging');
 
       expect(draggingItem).to.exist;
+    });
+  });
+
+  describe('Dynamic sortables', () => {
+    afterEach(() => {
+      ReactDOM.unmountComponentAtNode(document.getElementById('react'));
+    });
+
+    it('should automatically update when children change', () => {
+      ReactDOM.render(
+        <Sortable dynamic>
+          <DemoItem sortData="1" className="item-1" key={1}>1</DemoItem>
+          <DemoItem sortData="2" className="item-2" key={2}>2</DemoItem>
+        </Sortable>
+      , document.getElementById('react'));
+
+      ReactDOM.render(
+        <Sortable dynamic>
+          <DemoItem sortData="2" className="item-2" key={2}>2</DemoItem>
+          <DemoItem sortData="1" className="item-1" key={1}>1</DemoItem>
+          <DemoItem sortData="3" className="item-3" key={3}>3</DemoItem>
+        </Sortable>
+      , document.getElementById('react'));
+
+      let children = document.querySelectorAll('.ui-sortable-item');
+      expect(children.length).to.equal(3);
+      expect(children[0].textContent).to.equal('2');
+
+      ReactDOM.render(
+        <Sortable dynamic>
+          <DemoItem sortData="2" className="item-2" key={2}>2</DemoItem>
+          <DemoItem sortData="3" className="item-3" key={3}>3</DemoItem>
+        </Sortable>
+      , document.getElementById('react'));
+
+      children = document.querySelectorAll('.ui-sortable-item');
+      expect(children.length).to.equal(2);
+      expect(children[1].textContent).to.equal('3');
+    });
+  });
+
+  describe('A sortable with stateful items', () => {
+    afterEach(() => {
+      ReactDOM.unmountComponentAtNode(document.getElementById('react'));
+    });
+
+    it('should correctly reorder keyed items, maintaining state', () => {
+      ReactDOM.render(
+        <Sortable className="style-for-test">
+          <DemoItem sortData="1" className="item-1" key={1}><input size="3" /></DemoItem>
+          <DemoItem sortData="2" className="item-2" key={2}><input size="3" /></DemoItem>
+          <DemoItem sortData="3" className="item-3" key={3}><input size="3" /></DemoItem>
+        </Sortable>
+      , document.getElementById('react'));
+
+      let inputs = document.querySelectorAll('.ui-sortable-item input');
+      inputs[0].value = 'foo';
+      inputs[1].value = 'bar';
+      inputs[2].value = 'baz';
+
+      const target = document.querySelector('.ui-sortable-item');
+      moveX(target, 25, 210);
+
+      inputs = document.querySelectorAll('.ui-sortable-item input');
+
+      expect(inputs[0].value).to.equal('bar');
+      expect(inputs[1].value).to.equal('baz');
+      expect(inputs[2].value).to.equal('foo');
     });
   });
 });

--- a/test/specs/sortable-test.js
+++ b/test/specs/sortable-test.js
@@ -55,9 +55,9 @@ describe('Sortable', () => {
     beforeEach(() => {
       ReactDOM.render(
         <Sortable>
-          <DemoItem sortData="1" key={1} />
-          <DemoItem sortData="2" key={2} />
-          <DemoItem sortData="3" key={3} />
+          <DemoItem sortData="1" />
+          <DemoItem sortData="2" />
+          <DemoItem sortData="3" />
         </Sortable>
       , document.getElementById('react'));
     });
@@ -98,7 +98,7 @@ describe('Sortable', () => {
           {
             ['hello1', 'hello2', ''].map(name => {
               if (name) {
-                return (<DemoItem sortData={name} key={name} />);
+                return (<DemoItem sortData={name} />);
               }
 
               return null;
@@ -124,9 +124,9 @@ describe('Sortable', () => {
     beforeEach(() => {
       component = ReactDOM.render(
         <Sortable className="style-for-test">
-          <DemoItem sortData="1" className="item-1" key={1}>1</DemoItem>
-          <DemoItem sortData="2" className="item-2" key={2}>2</DemoItem>
-          <DemoItem sortData="3" className="item-3" key={3}>3</DemoItem>
+          <DemoItem sortData="1" className="item-1">1</DemoItem>
+          <DemoItem sortData="2" className="item-2">2</DemoItem>
+          <DemoItem sortData="3" className="item-3">3</DemoItem>
         </Sortable>
       , document.getElementById('react'));
     });
@@ -245,9 +245,9 @@ describe('Sortable', () => {
     beforeEach(() => {
       component = ReactDOM.render(
         <Sortable className="style-for-test full-width">
-          <DemoItem sortData="1" className="item-1" key={1}>1</DemoItem>
-          <DemoItem sortData="2" className="item-2" key={2}>2</DemoItem>
-          <DemoItem sortData="3" className="item-3" key={3}>3</DemoItem>
+          <DemoItem sortData="1" className="item-1">1</DemoItem>
+          <DemoItem sortData="2" className="item-2">2</DemoItem>
+          <DemoItem sortData="3" className="item-3">3</DemoItem>
         </Sortable>
       , document.getElementById('react'));
     });
@@ -285,11 +285,11 @@ describe('Sortable', () => {
       callback = chai.spy();
       component = ReactDOM.render(
         <Sortable className="style-for-test" onSort={callback}>
-          <DemoItem sortData="1" className="item-1" key={1}>1</DemoItem>
-          <div style={{ float: 'left', width: '50px', height: '50px'}} key='a'>fixed</div>
-          <DemoItem sortData="2" className="item-2" key={2}>2</DemoItem>
-          <div style={{ float: 'left', width: '50px', height: '50px'}} key='b'>fixed</div>
-          <DemoItem sortData="3" className="item-3" key={3}>3</DemoItem>
+          <DemoItem sortData="1" className="item-1">1</DemoItem>
+          <div style={{ float: 'left', width: '50px', height: '50px'}}>fixed</div>
+          <DemoItem sortData="2" className="item-2">2</DemoItem>
+          <div style={{ float: 'left', width: '50px', height: '50px'}}>fixed</div>
+          <DemoItem sortData="3" className="item-3">3</DemoItem>
         </Sortable>
       , document.getElementById('react'));
     });
@@ -326,9 +326,9 @@ describe('Sortable', () => {
 
       ReactDOM.render(
         <Sortable onSort={callback}>
-          <DemoItem sortData="1" className="item-1" key={1}>1</DemoItem>
-          <DemoItem sortData="2" className="item-2" key={2}>2</DemoItem>
-          <DemoItem sortData="3" className="item-3" key={3}>3</DemoItem>
+          <DemoItem sortData="1" className="item-1">1</DemoItem>
+          <DemoItem sortData="2" className="item-2">2</DemoItem>
+          <DemoItem sortData="3" className="item-3">3</DemoItem>
         </Sortable>
       , document.getElementById('react'));
     });
@@ -362,9 +362,9 @@ describe('Sortable', () => {
     it('should NOT move when mouse outside of Sortable container', () => {
       ReactDOM.render(
         <Sortable containment>
-          <DemoItem sortData="1" className="item-1" key={1}>1</DemoItem>
-          <DemoItem sortData="2" className="item-2" key={2}>2</DemoItem>
-          <DemoItem sortData="3" className="item-3" key={3}>3</DemoItem>
+          <DemoItem sortData="1" className="item-1">1</DemoItem>
+          <DemoItem sortData="2" className="item-2">2</DemoItem>
+          <DemoItem sortData="3" className="item-3">3</DemoItem>
         </Sortable>
       , document.getElementById('react'));
 
@@ -492,15 +492,15 @@ describe('Sortable', () => {
     it('should not move when `sortHandle` is set and target doesn\'t match', () => {
       ReactDOM.render(
         <Sortable sortHandle="handle">
-          <DemoItem sortData="1" className="item-1" key={1}>
+          <DemoItem sortData="1" className="item-1">
             1
             <span className="handle">↔</span>
           </DemoItem>
-          <DemoItem sortData="2" className="item-2" key={2}>
+          <DemoItem sortData="2" className="item-2">
             2
             <span className="handle">↔</span>
           </DemoItem>
-          <DemoItem sortData="3" className="item-3" key={3}>
+          <DemoItem sortData="3" className="item-3">
             3
             <span className="handle">↔</span>
           </DemoItem>
@@ -523,19 +523,19 @@ describe('Sortable', () => {
     it('should not throw when sort handle is/contains SVG', () => {
       ReactDOM.render(
         <Sortable sortHandle="handle">
-          <DemoItem sortData="1" className="item-1" key={1}>
+          <DemoItem sortData="1" className="item-1">
             1
             <span className="handle">
               <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.414"><path d="M.004.393H4.74l6.56 10.61-.003-10.61H16v15.214h-4.696L4.71 4.997v10.61H0L.004.393" fill-rule="nonzero"></path></svg>
             </span>
           </DemoItem>
-          <DemoItem sortData="2" className="item-2" key={2}>
+          <DemoItem sortData="2" className="item-2">
             2
             <span className="handle">
               <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.414"><path d="M.004.393H4.74l6.56 10.61-.003-10.61H16v15.214h-4.696L4.71 4.997v10.61H0L.004.393" fill-rule="nonzero"></path></svg>
             </span>
           </DemoItem>
-          <DemoItem sortData="3" className="item-3" key={3}>
+          <DemoItem sortData="3" className="item-3">
             3
             <span className="handle">
               <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.414"><path d="M.004.393H4.74l6.56 10.61-.003-10.61H16v15.214h-4.696L4.71 4.997v10.61H0L.004.393" fill-rule="nonzero"></path></svg>
@@ -594,16 +594,10 @@ describe('Sortable', () => {
       expect(children.length).to.equal(2);
       expect(children[1].textContent).to.equal('3');
     });
-  });
-
-  describe('A sortable with stateful items', () => {
-    afterEach(() => {
-      ReactDOM.unmountComponentAtNode(document.getElementById('react'));
-    });
 
     it('should correctly reorder keyed items, maintaining state', () => {
       ReactDOM.render(
-        <Sortable className="style-for-test">
+        <Sortable className="style-for-test" dynamic>
           <DemoItem sortData="1" className="item-1" key={1}><input size="3" /></DemoItem>
           <DemoItem sortData="2" className="item-2" key={2}><input size="3" /></DemoItem>
           <DemoItem sortData="3" className="item-3" key={3}><input size="3" /></DemoItem>
@@ -615,8 +609,13 @@ describe('Sortable', () => {
       inputs[1].value = 'bar';
       inputs[2].value = 'baz';
 
-      const target = document.querySelector('.ui-sortable-item');
-      moveX(target, 25, 210);
+      ReactDOM.render(
+        <Sortable className="style-for-test" dynamic>
+          <DemoItem sortData="2" className="item-2" key={2}><input size="3" /></DemoItem>
+          <DemoItem sortData="3" className="item-3" key={3}><input size="3" /></DemoItem>
+          <DemoItem sortData="1" className="item-1" key={1}><input size="3" /></DemoItem>
+        </Sortable>
+      , document.getElementById('react'));
 
       inputs = document.querySelectorAll('.ui-sortable-item input');
 


### PR DESCRIPTION
As suggested on #46, I'm making a pull request for my take on solving dynamic items in a better way. This ended up perhaps a bit more extensive than ideal, but I think it's solid. The pull request includes updated documentation and a couple of tests. I'm open to feedback and making improvements on this if required.

Some notes on the changes involved:

- To maintain backwards compatibility, the new dynamic behaviour is turned on using a new `dynamic` prop on Sortable. For users not using that prop, everything _should_ be the same as always (the tests pass, at least).

- Because the sortable was clobbering the keys the user defined for the sortable items and replacing them with the sortable index, dynamically updating the internal lists on sort meant the original key data for my sortable items got lost when I updated the children, and they'd get their props swapped around instead of the actual elements being reordered. I figured clobbering the user's keys is kind of dodgy anyway, so I made it only set a key if the item does not already have one. As far as I can tell there's no realistic scenario in which this would impact a real-world user, but by all means correct me if I've missed something.

- The dragging item now gets assigned the key '_dragging', since otherwise without the key-clobbering you'd get key conflicts if the user had defined a numerical key that happens to be equal to the length of the array.

- The original dynamic demo had the remove button do its thing on mousedown; this led to a bizarre issue where the removed item would be rendered on top of the first item, because the sortable was rerendered before the draggingIndex was reset on mouseup and then doesn't get rerendered again until the user starts to move something. If there was some reason to use mousedown there that I'm missing, some better solution to that is probably required, but as far as I could tell making it into a click handler instead solved the problem just fine.