### PR TITLE
bump react peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "webpack-dev-server": "^1.14.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "create-react-class": "^15.5.2",


### PR DESCRIPTION
Since #83 it seems react-anything-sortable works fine with react 16. Tests also pass when forced to run with react 16.